### PR TITLE
Only map keys when g:dwm_map_keys is 1

### DIFF
--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -117,17 +117,18 @@ function! DWM_Focus()
   endif
 endfunction
 
+if !exists('g:dwm_map_keys')
+    let g:dwm_map_keys = 1
+endif
 
+if g:dwm_map_keys
+    map <C-N> :call DWM_New()<CR>
+    map <C-C> :call DWM_Close()<CR>
+    map <C-H> :call DWM_Focus()<CR>
+    " map <C-B> :call DWM_Ball()<CR>
+    map <C-J> <C-W>w
+    map <C-K> <C-W>W
+    map <C-B> :ls<CR>
+endif
 
-
-
-map <C-N> :call DWM_New()<CR>
-map <C-C> :call DWM_Close()<CR>
-map <C-H> :call DWM_Focus()<CR>
-" map <C-B> :call DWM_Ball()<CR>
-
-map <C-J> <C-W>w
-map <C-K> <C-W>W
-
-map <C-B> :ls<CR>
 


### PR DESCRIPTION
It is a good idea to give the user the possibility to override the default key
mappings. With this commit the user can set g:dwm_map_keys to 0 and call the dwm
functions himself. If the variable is not set at all it is assumed to be 1.
The solution is taken from a blog post by Steve Losh's [1].

[1] http://stevelosh.com/blog/2011/09/writing-vim-plugins/#mapping-keys-the-right-way
