### PR TITLE
Shuffle windows instead of rebuilding

### DIFF
--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -43,17 +43,12 @@ endif
 " +--------+--------+
 
 " Move the current master pane to the stack
-function! DWM_Stack(clockwise)
+function! DWM_Stack()
   1wincmd w
-  if a:clockwise
-    " Move to the top of the stack
-    wincmd K
-  else
-    " Move to the bottom of the stack
-    wincmd J
-  endif
+  " Move to the top of the stack
+  wincmd K
   " At this point, the layout *should* be the following with the previous master
-  " at the top (rotated clockwise) or bottom (rotated anticlockwise).
+  " at the top.
   " +-----------------+
   " |        M        |
   " +-----------------+
@@ -65,25 +60,10 @@ function! DWM_Stack(clockwise)
   " +-----------------+
 endfunction
 
-" Rotate the layout clockwise or anticlockwise
-function! DWM_Rotate(clockwise)
-  " Move master pane to appropriate position on the stack
-  call DWM_Stack(a:clockwise)
-  " Select next or previous window
-  if a:clockwise
-    wincmd W
-  else
-    wincmd w
-  endif
-  " Move to left
-  wincmd H
-  call DWM_ResizeMasterPaneWidth()
-endfunction
-
 " Add a new buffer
 function! DWM_New()
   " Move current master pane to the stack
-  call DWM_Stack(1)
+  call DWM_Stack()
   " Create a vertical split
   vert topleft new
   call DWM_ResizeMasterPaneWidth()
@@ -93,7 +73,7 @@ endfunction
 " added to the top of the stack)
 function! DWM_Focus()
   let l:curwin = winnr()
-  call DWM_Stack(1)
+  call DWM_Stack()
   exec l:curwin . "wincmd w"
   wincmd H
   call DWM_ResizeMasterPaneWidth()
@@ -139,6 +119,9 @@ if !exists('g:dwm_map_keys')
 endif
 
 if g:dwm_map_keys
+  map <C-J> <C-W>w
+  map <C-K> <C-W>W
+
   map <C-N> :call DWM_New()<CR>
   map <C-C> :call DWM_Close()<CR>
   map <C-Space> :call DWM_Focus()<CR>
@@ -146,7 +129,4 @@ if g:dwm_map_keys
 
   map <C-H> :call DWM_GrowMaster()<CR>
   map <C-L> :call DWM_ShrinkMaster()<CR>
-
-  map <C-J> :call DWM_Rotate(1)<CR>
-  map <C-K> :call DWM_Rotate(0)<CR>
 endif

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -119,6 +119,22 @@ function! DWM_ResizeMasterPaneWidth()
   endif
 endfunction
 
+function! DWM_GrowMaster()
+  if winnr() == 1
+    exec "vertical resize +1"
+  else
+    exec "vertical resize -1"
+  endif
+endfunction
+
+function! DWM_ShrinkMaster()
+  if winnr() == 1
+    exec "vertical resize -1"
+  else
+    exec "vertical resize +1"
+  endif
+endfunction
+
 if !exists('g:dwm_map_keys')
   let g:dwm_map_keys = 1
 endif
@@ -128,6 +144,10 @@ if g:dwm_map_keys
   map <C-C> :call DWM_Close()<CR>
   map <C-Space> :call DWM_Focus()<CR>
   map <C-@> :call DWM_Focus()<CR>
+
+  map <C-H> :call DWM_GrowMaster()<CR>
+  map <C-L> :call DWM_ShrinkMaster()<CR>
+
   map <C-J> :call DWM_Rotate(1)<CR>
   map <C-K> :call DWM_Rotate(0)<CR>
 endif

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -101,14 +101,14 @@ endfunction
 
 " Close the current window
 function! DWM_Close()
-  bd
-  " If the master panel is closed, only the stack remains and its witdh is equal
-  " to the width of the editor
-  if winwidth('%') == &columns
-    " Move the current window to the master panel
+  if winnr() == 1
+    " Close master panel.
+    bd
     wincmd H
     call DWM_ResizeMasterPaneWidth()
-  endif
+  else
+    bd
+  end
 endfunction
 
 function! DWM_ResizeMasterPaneWidth()

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -44,8 +44,7 @@ endif
 
 " Move the current master pane to the stack
 function! DWM_Stack(clockwise)
-  " Select window on the left, this *should* be the master pane
-  wincmd h
+  1wincmd w
   if a:clockwise
     " Move to the top of the stack
     wincmd K


### PR DESCRIPTION
I love this plugin and I've been thinking a lot about my ideal workflow. I've hacked on a few changes that I would like to see (multiple master windows in #17) and in doing so have stumbled across a few issues due to the approach dwm.vim takes by completely rebuilding windows from all open buffers.
1. The first is I, like @milkmiruku, love my tabs. At present, all open buffers will be shown in all tabs.
2. I'll frequently open a file from another project and `:lcd` to its project directory so I can work from within the project. Every time `DWM_Ball` is called, all windows are destroyed which means the `:lcd` setting is either lost or all new windows will inherit it.

I've been thinking through how I might approach this project of window management in vim. I'm not well versed in vimscript so I would first try the naive approach of using `<C-w>` prefixed mappings. Here's the workflow I recorded. It works in that the outcome is what I expect assuming only 4 open windows.

```
<C-w>H<C-w>w<C-w>J2<C-w>w<C-w>J2<C-w>w<C-w>J<C-w>w<C-w>H
```

Broken down:

Start (bracketed window is active):

```
-------------------------------------
|                 |        S1       |
|                 |-----------------|
|        M        |       [S2]      |
|                 |-----------------|
|                 |        S3       |
-------------------------------------
```

Move S2 left: `<C-w>H`

```
-------------------------------------
|           |           |           |
|           |           |    S1     |
|   [S2]    |     M     |-----------|
|           |           |    S3     |
|           |           |           |
-------------------------------------
```

Move M bottom: `<C-w>w <C-w>J`

```
-------------------------------------
|                 |        S1       |
|       S2        |-----------------|
|                 |        S3       |
|-----------------------------------|
|                [M]                |
-------------------------------------
```

Move S1 down: `2<C-w>w <C-w>J`

```
-------------------------------------
|       S2        |        S3       |
|-----------------------------------|
|                 M                 |
|-----------------------------------|
|               [S1]                |
-------------------------------------
```

Move S3 down: `2<C-w>w <C-w>J`

```
-------------------------------------
|                S2                 |
|-----------------------------------|
|                 M                 |
|-----------------------------------|
|                S1                 |
|-----------------------------------|
|               [S3]                |
-------------------------------------
```

Move S2 left: `<C-w>w <C-w>H`

```
-------------------------------------
|                 |         M       |
|                 |-----------------|
|      [S2]       |        S1       |
|                 |-----------------|
|                 |        S3       |
-------------------------------------
```

I'm sure with some simple vimscript this shuffling window technique could be extended to support any number of open windows.
