### PR TITLE
Why mapping <C-b>?

### DIFF
--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -143,5 +143,4 @@ if g:dwm_map_keys
   " map <C-B> :call DWM_Ball()<CR>
   map <C-J> <C-W>w
   map <C-K> <C-W>W
-  map <C-B> :ls<CR>
 endif


### PR DESCRIPTION
`<C-b>` is for scrolling pages, I definitely need it.

I need other mappings like `<C-n>`, so `g:dwm_map_keys` is not useful to me.

I recommend to delete this mapping, typing `:ls` is not so painful.
