### PR TITLE
Relative width for master pane

### DIFF
--- a/doc/dwm.txt
+++ b/doc/dwm.txt
@@ -97,9 +97,14 @@ If enabled, dwm maps control keys to the commands.
 
                                                    *'g:dwm_master_pane_width'*
 Default: ?
-Set the width of the master pane.
+Set the width of the master pane. If the value is given as a string, the width
+will be set to a relative percentage of the editor's width.
 >
+    "set master pane width to 85 columns
     let g:dwm_master_pane_width=85
+    
+    "set master pane width to 66% of editor width
+    let g:dwm_master_pane_width="66%"
 <
 
 

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -102,7 +102,11 @@ endfunction
 function DWM_ResizeMasterPaneWidth()
   " resize the master pane if user defined it
   if exists('g:dwm_master_pane_width')
-    exec 'vertical resize ' . g:dwm_master_pane_width
+    if type(g:dwm_master_pane_width) == type("")
+      exec 'vertical resize ' . ((str2nr(g:dwm_master_pane_width)*&columns)/100)
+    else
+      exec 'vertical resize ' . g:dwm_master_pane_width
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
I often resize my terminal, and in some cases I want to have the master pane take a relative percentage of the terminal's width rather than having a fixed width.

```
"fixed width, 80 columns
let g:dwm_master_pane_width = 80

"relative width, 66% of vim's width
let g:dwm_master_pane_width = "66%" 
```
