### PR TITLE
[Bug] Focus to the wrong buffer when user open buffers using :e file command

### DIFF
--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -128,11 +128,18 @@ function! DWM_Close()
   call DWM_Layout()
 endfunction
 
+function! DWM_CloseOthers()
+  for nr in range(1,bufnr("$"))
+    if nr != bufnr('%') && buflisted(nr)
+        exec 'bd ' . nr
+    endif
+  endfor
+endfunction
+
 function! DWM_Focus()
   call DWM_Ball()
   call DWM_Layout()
 endfunction
-
 
 if !exists('g:dwm_map_keys')
   let g:dwm_map_keys = 1
@@ -140,10 +147,9 @@ endif
 
 if g:dwm_map_keys
   map <C-N> :call DWM_New()<CR>
-  map <C-C> :call DWM_Close()<CR>
+  map <C-C> :call DWM_CloseOthers()<CR>
   map <C-H> :call DWM_Focus()<CR>
   map <C-L> :call DWM_Full()<CR>
-  " map <C-B> :call DWM_Ball()<CR>
   map <C-J> <C-W>w
   map <C-K> <C-W>W
 endif

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -75,7 +75,11 @@ endfunction
 
 
 function! DWM_Ball()
+  " when user open buffers with `:e file` command,
+  " the s:dwm_bufs will be [] until the following call to DWM_SyncBufs(),
   call DWM_SyncBufs()
+  " then we need to set focus to the RIGHT buffer using DWM_TopBuf()
+  call DWM_TopBuf(bufnr('%'))
   exec 'sb ' . s:dwm_bufs[len(s:dwm_bufs)-1]
   on!
   call DWM_SyncBufs()
@@ -116,7 +120,6 @@ function! DWM_New ()
   call DWM_Ball()
   vert topleft new
   call DWM_SyncBufs()
-  call DWM_TopBuf(bufnr('%'))
   call DWM_ResizeMasterPaneWidth()
 endfunction
 
@@ -126,7 +129,7 @@ function! DWM_Close()
 endfunction
 
 function! DWM_Focus()
-  call DWM_TopBuf(bufnr('%'))
+  call DWM_Ball()
   call DWM_Layout()
 endfunction
 


### PR DESCRIPTION
The bug can be reproduced like this:

Open vim and then run the two command: `:e afile` and `:e bfile`. Then when push `<C-H>` dwm focus the wrong file: `afile` to master pane. But we are expect it to be `bfile`.
