### PR TITLE
Ignore generated helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 *.swp
 *~
-
+/doc/tags


### PR DESCRIPTION
When using a bundled setup with pathogen, helptags are usually
auto-generated. This is particularly annoying with submodules.
