### PR TITLE
Autocommands for automatic layout updates

### DIFF
--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -104,7 +104,7 @@ function! DWM_AutoEnter()
   endif
 
   " Recreate stack
-  while i <= j
+  while i < j
     let i += 1
     exec j. 'wincmd w'
     wincmd K
@@ -118,9 +118,11 @@ endfunction
 " Handler for BufWinLeave autocommand
 " Fix layout broken by closed master window
 function! DWM_AutoLeave()
-  " FIXME: Netrw magic hides another buffer when file is opened.
-  " Possible solution - call unhide in DWM_AutoEnter
-  if winnr() == 1 && &l:ft != 'netrw'
+  if winnr('$') < 2
+    return
+  endif
+
+  if winnr() == 1
     wincmd K
     wincmd x
     wincmd H
@@ -233,7 +235,7 @@ endif
 if has('autocmd')
   augroup dwm
     au!
-    au BufWinEnter * call DWM_AutoEnter()
-    au BufWinLeave * call DWM_AutoLeave()
+    au BufWinEnter * if &l:ft !~ '\v^(netrw|help)$' | call DWM_AutoEnter() | endif
+    au BufWinEnter * if &l:ft !~ '\v^(netrw|help)$' | call DWM_AutoLeave() | endif
   augroup end
 endif

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -236,7 +236,11 @@ endif
 if has('autocmd')
   augroup dwm
     au!
-    au BufWinEnter * if &l:filetype !~ '\v^(netrw|help)$' | call DWM_AutoEnter() | endif
+
+    au BufWinEnter * if &l:filetype !~ '\v^(netrw|help)$' |
+      \ call feedkeys("\<C-\>\<C-n>:silent call DWM_AutoEnter()\<CR>", 'n') |
+    \ endif
+
     au BufWinLeave * if &l:filetype !~ '\v^(netrw|help)$' | call DWM_AutoLeave() | endif
   augroup end
 endif

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -96,23 +96,16 @@ endfunction
 " Handler for BufWinEnter autocommand
 " Recreate layout broken by new window
 function! DWM_AutoEnter()
-  let i = 1
-  let j = winnr('$')
-
-  if j < 2
+  if winnr('$') == 1
     return
   endif
 
-  " Recreate stack
-  while i < j
-    let i += 1
-    exec j. 'wincmd w'
-    wincmd K
-  endwhile
+  " Move new window to stack top
+  wincmd K
 
-  " Put master on its place
-  wincmd H
-  call DWM_ResizeMasterPaneWidth()
+  " Focus new window (twice :)
+  call DWM_Focus()
+  call DWM_Focus()
 endfunction
 
 " Handler for BufWinLeave autocommand

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -236,11 +236,7 @@ endif
 if has('autocmd')
   augroup dwm
     au!
-
-    au BufWinEnter * if &l:filetype !~ '\v^(netrw|help)$' |
-      \ call feedkeys("\<C-\>\<C-n>:silent call DWM_AutoEnter()\<CR>", 'n') |
-    \ endif
-
+    au BufWinEnter * if &l:filetype !~ '\v^(netrw|help)$' | call DWM_AutoEnter() | endif
     au BufWinLeave * if &l:filetype !~ '\v^(netrw|help)$' | call DWM_AutoLeave() | endif
   augroup end
 endif

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -108,29 +108,9 @@ function! DWM_AutoEnter()
   call DWM_Focus()
 endfunction
 
-" Handler for BufWinLeave autocommand
-" Fix layout broken by closed master window
-function! DWM_AutoLeave()
-  if winnr('$') < 2
-    return
-  endif
-
-  " To prevent vim crashes filetype is checked
-  " before any actual layout changes. So layout
-  " is updated only for regular buffers. Probably
-  " other buffer properties should be also checked.
-  if winnr() == 1 && strlen(&l:filetype)
-    wincmd K
-    wincmd x
-    wincmd H
-    call DWM_ResizeMasterPaneWidth()
-  endif
-endfunction
-
 " Close the current window
 function! DWM_Close()
-  " For buffers with filetype set layout will be changed by DWM_AutoLeave()
-  if winnr() == 1 && (!strlen(&l:filetype) || &l:filetype =~ '\v^(netrw|help)$')
+  if winnr() == 1
     " Close master panel.
     return 'close | wincmd H | call DWM_ResizeMasterPaneWidth()'
   else
@@ -237,6 +217,5 @@ if has('autocmd')
   augroup dwm
     au!
     au BufWinEnter * if &l:filetype !~ '\v^(netrw|help)$' | call DWM_AutoEnter() | endif
-    au BufWinLeave * if &l:filetype !~ '\v^(netrw|help)$' | call DWM_AutoLeave() | endif
   augroup end
 endif

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -236,6 +236,6 @@ if has('autocmd')
   augroup dwm
     au!
     au BufWinEnter * if &l:ft !~ '\v^(netrw|help)$' | call DWM_AutoEnter() | endif
-    au BufWinEnter * if &l:ft !~ '\v^(netrw|help)$' | call DWM_AutoLeave() | endif
+    au BufWinLeave * if &l:ft !~ '\v^(netrw|help)$' | call DWM_AutoLeave() | endif
   augroup end
 endif

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -115,7 +115,11 @@ function! DWM_AutoLeave()
     return
   endif
 
-  if winnr() == 1
+  " To prevent vim crashes filetype is checked
+  " before any actual layout changes. So layout
+  " is updated only for regular buffers. Probably
+  " other buffer properties should be also checked.
+  if winnr() == 1 && strlen(&l:filetype)
     wincmd K
     wincmd x
     wincmd H
@@ -125,7 +129,8 @@ endfunction
 
 " Close the current window
 function! DWM_Close()
-  if winnr() == 1
+  " For buffers with filetype set layout will be changed by DWM_AutoLeave()
+  if winnr() == 1 && (!strlen(&l:filetype) || &l:filetype =~ '\v^(netrw|help)$')
     " Close master panel.
     return 'close | wincmd H | call DWM_ResizeMasterPaneWidth()'
   else
@@ -134,6 +139,9 @@ function! DWM_Close()
 endfunction
 
 function! DWM_ResizeMasterPaneWidth()
+  " Make all windows equally high and wide
+  wincmd =
+
   " resize the master pane if user defined it
   if exists('g:dwm_master_pane_width')
     if type(g:dwm_master_pane_width) == type("")
@@ -228,7 +236,7 @@ endif
 if has('autocmd')
   augroup dwm
     au!
-    au BufWinEnter * if &l:ft !~ '\v^(netrw|help)$' | call DWM_AutoEnter() | endif
-    au BufWinLeave * if &l:ft !~ '\v^(netrw|help)$' | call DWM_AutoLeave() | endif
+    au BufWinEnter * if &l:filetype !~ '\v^(netrw|help)$' | call DWM_AutoEnter() | endif
+    au BufWinLeave * if &l:filetype !~ '\v^(netrw|help)$' | call DWM_AutoLeave() | endif
   augroup end
 endif

--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -93,6 +93,41 @@ function! DWM_Focus()
   call DWM_ResizeMasterPaneWidth()
 endfunction
 
+" Handler for BufWinEnter autocommand
+" Recreate layout broken by new window
+function! DWM_AutoEnter()
+  let i = 1
+  let j = winnr('$')
+
+  if j < 2
+    return
+  endif
+
+  " Recreate stack
+  while i <= j
+    let i += 1
+    exec j. 'wincmd w'
+    wincmd K
+  endwhile
+
+  " Put master on its place
+  wincmd H
+  call DWM_ResizeMasterPaneWidth()
+endfunction
+
+" Handler for BufWinLeave autocommand
+" Fix layout broken by closed master window
+function! DWM_AutoLeave()
+  " FIXME: Netrw magic hides another buffer when file is opened.
+  " Possible solution - call unhide in DWM_AutoEnter
+  if winnr() == 1 && &l:ft != 'netrw'
+    wincmd K
+    wincmd x
+    wincmd H
+    call DWM_ResizeMasterPaneWidth()
+  endif
+endfunction
+
 " Close the current window
 function! DWM_Close()
   if winnr() == 1
@@ -193,4 +228,12 @@ if g:dwm_map_keys
   if !hasmapto('<Plug>DWMShrinkMaster')
       nmap <C-H> <Plug>DWMShrinkMaster
   endif
+endif
+
+if has('autocmd')
+  augroup dwm
+    au!
+    au BufWinEnter * call DWM_AutoEnter()
+    au BufWinLeave * call DWM_AutoLeave()
+  augroup end
 endif


### PR DESCRIPTION
Hi,

Tried to improve layout management.

Solved issues (see #37):
- `:new`
- `:help`
- `:q` and similar

Remains:
- `:split` without arguments from master
- `:Ex` netrw has lots of deep magic so I disabled event handling for buffers with `netrw` type

Please, check carefully before merge =)
