### PR TITLE
#50: Disable in vimdiff mode

### DIFF
--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -20,7 +20,7 @@
 "==============================================================================
 
 " Exit quickly if already running
-if exists("g:dwm_version") || &cp
+if exists("g:dwm_version") || &diff || &cp
   finish
 endif
 


### PR DESCRIPTION
Checking for non-diff mode before activating dwm.vim
