### PR TITLE
Remove mentions of DWM_Full, which was removed by #18

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,6 @@ Use the following commands to create, browse and close windows:
 - `C-J` Jumps to next window (clockwise) 
 - `C-K` Jumps to previous window (anti-clockwise) 
 - `C-Space` Focus the current window, that is, place it in the master pane [M] & stacks all other windows in the stacked pane [S]
-- `C-M` Fullscreen mode for the current window (use focus to return to normal mode)
 
 ### ScreenShot
 

--- a/doc/dwm.txt
+++ b/doc/dwm.txt
@@ -35,8 +35,7 @@ master pane on the left and a stacked pane on the right side:
 new empty buffer. The previous master window is pushed on top of the stacked
 pane. |:DWM_Closes| closes any window as long as no unsaved changes are
 pending and updates the layout. An active, stacked window is focused and moved
-to the master pane with |:DWM_Focus|. Any window can occupy the full screen
-with |:DWM_Full| and return from that state with |:DWM_Focus|.
+to the master pane with |:DWM_Focus|.
 
 Official releases can be found on vim.org:
 
@@ -65,12 +64,6 @@ Closes the active window if no unsaved changes are pending.
 Focus the active window by placing it in the master pane.
 
 
-:DWM_Full                                                          *:DWM_Full*
-
-Make the active window full screen. Use |'DWM_Focus'| to return to normal
-mode.
-
-
 ==============================================================================
 MAPPINGS                                                        *dwm-mappings*
 
@@ -80,7 +73,6 @@ mapped:
   <c-n>     |:DWM_New|
   <c-c>     |:DWM_Close|
   <c-space> |:DWM_Focus|
-  <c-m>     |:DWM_Full|
   <c-j>     Move cursor clockwise to the next window
   <c-k>     Move cursor counter-clockwise to the previous window
   <c-,>     Rotate windows counter-clockwise


### PR DESCRIPTION
Pull request #18 refactored the layout code, but did not re-implement the DWM_Full function that fullscreened a window. Since the C-M command was still referenced by the documentation, it was confusing that the fullscreen command stopped working after updating dwm.vim.
