### PR TITLE
Skip layout updates triggered by quickfix buffers

### DIFF
--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -100,6 +100,16 @@ function! DWM_AutoEnter()
     return
   endif
 
+  " Skip buffers without filetype
+  if !len(&l:filetype)
+    return
+  endif
+
+  " Skip quickfix buffers
+  if &l:buftype == 'quickfix'
+    return
+  endif
+
   " Move new window to stack top
   wincmd K
 


### PR DESCRIPTION
Problem described in #54.

Now quickfix window is not touched on open (`:botright cwindow`) but it's affected by manual layout updates. Looks like we have no way to exclude some windows from layout completely. I've tried to close all qf windows on layout updates and reopen them later, but this approach works only with error list and not with location list. Experiments with `:hide` also gave me nothing.

This PR breaks `:new` call without arguments (`<C-N>` works and `:new myfile` works when filetype detected).
