### PR TITLE
Fix for coc and languageclient-neovim documents opening in master area

### DIFF
--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -110,6 +110,11 @@ function! DWM_AutoEnter()
     return
   endif
 
+  " Skip if COC document or LanguageClient document
+  if @% == 'coc://document' || @% == '__LanguageClient__'
+    return
+  endif
+
   " Move new window to stack top
   wincmd K
 


### PR DESCRIPTION
Fix for hover document buffers becoming new master for [COC](https://github.com/neoclide/coc.nvim) and [Languageclient-neovim](https://github.com/autozimu/LanguageClient-neovim).