### PR TITLE
Disable all features if var is set

### DIFF
--- a/plugin/dwm.vim
+++ b/plugin/dwm.vim
@@ -226,6 +226,6 @@ endif
 if has('autocmd')
   augroup dwm
     au!
-    au BufWinEnter * if &l:buflisted || &l:filetype == 'help' | call DWM_AutoEnter() | endif
+    au BufWinEnter * if !get(b:, 'dwm_disabled', 0) && (&l:buflisted || &l:filetype == 'help') | call DWM_AutoEnter() | endif
   augroup end
 endif


### PR DESCRIPTION
I want to disable dwm.vim at only specified windows. For example, [denite.nvim][] opens a complecated & multifunctional window, so I want to make denite manage the window, not by dwm.vim.

[denite.nvim]: https://github.com/Shougo/denite.nvim

This PR introduces a buffer-specific variable: `b:dwm_disabled`. When you want to exclude some windows under dwm.vim's, you can achieve it with using `autocmd`.

```vim
autocmd FileType foo :let b:dwm_disabled = 1
" or
autocmd BufEnter some-bufname :let b:dwm_disabled = 1
" and so on
```

Perhaps, #70 can be realized by this PR and similar methods above.